### PR TITLE
build: add gradle publishMod task

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "com.github.johnrengelman.shadow" version "7.1.2"
+    id "me.modmuss50.mod-publish-plugin" version "0.8.4"
 }
 
 architectury {
@@ -76,4 +77,27 @@ publishing {
     repositories {
         // Add repositories to publish to here.
     }
+}
+
+publishMods {
+    file = remapJar.archiveFile
+    changelog = "Changelog"
+    type = STABLE
+    modLoaders.add("fabric")
+
+    modrinth {
+        accessToken = providers.environmentVariable("MODRINTH_API_KEY")
+        projectId = "<PROJECT ID>"
+        announcementTitle = "Download from Modrinth"
+        minecraftVersions.add("1.21.4")
+    }
+
+/*
+    curseforge {
+        accessToken = providers.environmentVariable("CURSEFORGE_API_KEY")
+        projectId = "<PROJECT ID>"
+        announcementTitle = "Download from CurseForge"
+        minecraftVersions.add("1.21.4")
+    }
+*/
 }

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "com.github.johnrengelman.shadow" version "7.1.2"
+    id "me.modmuss50.mod-publish-plugin" version "0.8.4"
 }
 
 architectury {
@@ -61,3 +62,25 @@ components.java {
     }
 }
 
+publishMods {
+    file = remapJar.archiveFile
+    changelog = "Changelog"
+    type = STABLE
+    modLoaders.add("neoforge")
+
+    modrinth {
+        accessToken = providers.environmentVariable("MODRINTH_API_KEY")
+        projectId = "<PROJECT ID>"
+        announcementTitle = "Download from Modrinth"
+        minecraftVersions.add("1.21.4")
+    }
+
+/*
+    curseforge {
+        accessToken = providers.environmentVariable("CURSEFORGE_API_KEY")
+        projectId = "<PROJECT ID>"
+        minecraftVersions.add("1.21.4")
+        announcementTitle = "Download from CurseForge"
+    }
+*/
+}


### PR DESCRIPTION
The configuration is still incomplete.
- The \<Project ID\> should be replaced with the corresponding project ID in Modrinth or CurseForge.
- Changelog and Readme can be handled better.
- Curseforge is commented out for now.
- CURSEFORGE_API_KEY and MODRINTH_API_KEY must be provided by the environment. This can be done by setting these two variables in the shell, or Add Environment Variables settings in Windows or by using _IDE's built in environment editor_.